### PR TITLE
Fix Excessive Timeouts

### DIFF
--- a/shared-data/default-theme/html/jsapi/global/eventlog.js
+++ b/shared-data/default-theme/html/jsapi/global/eventlog.js
@@ -63,11 +63,13 @@ EventLog.poll = function() {
   //
   //time for server to wait for new events
   var waittime = 30;
+  //extra time to account for processing time on backend
+  var buffer = 5;
   EventLog.request({
     since: EventLog.last_ts,
     gather: (EventLog.last_ts < 0) ? 0.2 : 1.0,
     wait: waittime,
-    _timeout: (waittime+1)*1000
+    _timeout: (waittime+buffer)*1000
   });
 };
 

--- a/shared-data/default-theme/html/jsapi/global/eventlog.js
+++ b/shared-data/default-theme/html/jsapi/global/eventlog.js
@@ -61,11 +61,13 @@ EventLog.poll = function() {
   // 3) Other tabs may rely on us putting things in localStorage that we
   //    ourselves don't care about.
   //
+  //time for server to wait for new events
+  var waittime = 30;
   EventLog.request({
     since: EventLog.last_ts,
     gather: (EventLog.last_ts < 0) ? 0.2 : 1.0,
-    wait: 30,
-    _timeout: (Mailpile.ajax_timeout * 3)
+    wait: waittime,
+    _timeout: (waittime+1)*1000
   });
 };
 


### PR DESCRIPTION
Fixes excessive timeouts by adding a 5 second buffer to the ajax request timeout and basing the timeout on the given wait time to account for server overhead when no new events are found.